### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/KerbthulhuKineticsProgram/MoarKerbalsParts/MoarKerbalsParts.version
+++ b/GameData/KerbthulhuKineticsProgram/MoarKerbalsParts/MoarKerbalsParts.version
@@ -1,6 +1,6 @@
 {
 	"NAME"     : "MoarKerbals Parts (MOARP)",
-	"URL"      : "https://raw.githubusercontent.com/zer0Kerbal/MoarKerbalsParts/master/GameData/MoarKerbals/MoarKerbals.version",
+	"URL"      : "https://raw.githubusercontent.com/zer0Kerbal/MoarKerbalsParts/master/GameData/KerbthulhuKineticsProgram/MoarKerbalsParts/MoarKerbalsParts.version",
 	"DOWNLOAD" : "https://github.com/zer0Kerbal/MoarKerbalsParts/releases/latest",
 	"CHANGE_LOG_URL":"https://raw.githubusercontent.com/zer0Kerbal/MoarKerbalsParts/Changelog.cfg",
 	"GITHUB" :


### PR DESCRIPTION
The version file URL property is a 404 (wrong filename, missing part of the path).
Now it's fixed.

Noticed while reviewing KSP-CKAN/NetKAN#8871.